### PR TITLE
Add multicastDNS for easier testing in development enviorment

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -6,6 +6,7 @@ from pydantic_settings import BaseSettings
 
 class GeneralConfig(BaseSettings):
     LOG_LEVEL: Literal["INFO", "WARNING", "ERROR"] = "INFO"
+    use_multicast_dns: bool = True
 
 
 class FastAPISettings(BaseSettings):

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,11 @@
+from typing import Literal
+
 from hypercorn import Config
 from pydantic_settings import BaseSettings
+
+
+class GeneralConfig(BaseSettings):
+    LOG_LEVEL: Literal["INFO", "WARNING", "ERROR"] = "INFO"
 
 
 class FastAPISettings(BaseSettings):

--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,11 @@ class GeneralConfig(BaseSettings):
     use_multicast_dns: bool = True
 
 
+class mDNSConfig(BaseSettings):
+    hostname: str = "adaptiq_indoor_localization"
+    port: int = 8001
+
+
 class FastAPISettings(BaseSettings):
     title: str = "Indoor Localization Backend"
     description: str = "# TODO write me down!"

--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,4 @@
+from hypercorn import Config
 from pydantic_settings import BaseSettings
 
 
@@ -5,9 +6,18 @@ class FastAPISettings(BaseSettings):
     title: str = "Indoor Localization Backend"
     description: str = "# TODO write me down!"
     version: str = "0.0.0"
+    debug: bool = True
 
 
-class UvicornConfig(BaseSettings):
+class ASGIConfig(BaseSettings):
     app: str = "app:app"
-    host: str = "localhost"
+    host: str = "127.0.0.1"
     port: int = 8000
+
+
+class HypercornConfig(Config):
+    def __init__(self) -> None:
+        super().__init__()
+        config = ASGIConfig()
+        self.bind = f"{config.host}:{config.port}"
+        self.loglevel = "INFO"

--- a/app/functions/logger.py
+++ b/app/functions/logger.py
@@ -1,0 +1,48 @@
+from logging.config import dictConfig
+
+from app.config import GeneralConfig
+
+
+def setup_logger() -> None:
+    config = GeneralConfig()
+
+    dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "hypercorn_like": {
+                    "format": "[%(asctime)s] [%(levelname)s] %(message)s",
+                    "datefmt": "%Y-%m-%d %H:%M:%S",
+                },
+            },
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "formatter": "hypercorn_like",
+                    "level": "INFO",
+                },
+            },
+            "loggers": {
+                "fastapi": {  # FastAPI application logs
+                    "handlers": ["console"],
+                    "level": "INFO",
+                    "propagate": False,
+                },
+                "hypercorn.error": {  # Hypercorn error logs
+                    "handlers": ["console"],
+                    "level": "INFO",
+                    "propagate": False,
+                },
+                "hypercorn.access": {  # Hypercorn access logs
+                    "handlers": ["console"],
+                    "level": "INFO",
+                    "propagate": False,
+                },
+            },
+            "root": {  # Root logger
+                "handlers": ["console"],
+                "level": "INFO",
+            },
+        }
+    )

--- a/app/functions/middleware.py
+++ b/app/functions/middleware.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from app.config import GeneralConfig
 from app.functions.logger import setup_logger
 from app.functions.multicast_dns import MulticastDNS
 from app.models.common import init_orm
@@ -11,10 +12,18 @@ from app.models.common import init_orm
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     setup_logger()
-    multicast_dns = MulticastDNS("indoor_localization", 8001)
     logging.info("Starting the application")
+
+    config = GeneralConfig()
+    multicast_dns: MulticastDNS | None = None
+
     init_orm()
-    await multicast_dns.register_service()
+
+    if config.use_multicast_dns:
+        multicast_dns = MulticastDNS("indoor_localization", 8001)
+        await multicast_dns.register_service()
     yield
-    await multicast_dns.unregister_service()
+
+    if multicast_dns:
+        await multicast_dns.unregister_service()
     logging.warning("Shutting down the application")

--- a/app/functions/middleware.py
+++ b/app/functions/middleware.py
@@ -3,12 +3,14 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from app.functions.logger import setup_logger
 from app.models.common import init_orm
 
 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
-    logging.info(f"Starting the application: ENV= # TODO ADD ENV LOADING")
+    setup_logger()
+    logging.info("Starting the application")
     init_orm()
     yield
     logging.warning("Shutting down the application")

--- a/app/functions/middleware.py
+++ b/app/functions/middleware.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
-from app.config import GeneralConfig
+from app.config import GeneralConfig, mDNSConfig
 from app.functions.logger import setup_logger
 from app.functions.multicast_dns import MulticastDNS
 from app.models.common import init_orm
@@ -19,11 +19,18 @@ async def lifespan(_: FastAPI):
 
     init_orm()
 
-    if config.use_multicast_dns:
-        multicast_dns = MulticastDNS("indoor_localization", 8001)
-        await multicast_dns.register_service()
+    multicast_dns = await init_mdns(config)
+
     yield
 
     if multicast_dns:
         await multicast_dns.unregister_service()
     logging.warning("Shutting down the application")
+
+
+async def init_mdns(config) -> MulticastDNS:
+    if config.use_multicast_dns:
+        mdns_config = mDNSConfig()
+        multicast_dns = MulticastDNS(mdns_config.hostname, mdns_config.port)
+        await multicast_dns.register_service()
+    return multicast_dns

--- a/app/functions/middleware.py
+++ b/app/functions/middleware.py
@@ -4,13 +4,17 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from app.functions.logger import setup_logger
+from app.functions.multicast_dns import MulticastDNS
 from app.models.common import init_orm
 
 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     setup_logger()
+    multicast_dns = MulticastDNS("indoor_localization", 8001)
     logging.info("Starting the application")
     init_orm()
+    await multicast_dns.register_service()
     yield
+    await multicast_dns.unregister_service()
     logging.warning("Shutting down the application")

--- a/app/functions/multicast_dns.py
+++ b/app/functions/multicast_dns.py
@@ -1,0 +1,17 @@
+from zeroconf import ServiceInfo, Zeroconf
+
+
+def register_service(hostname: str, port: int) -> tuple[Zeroconf, ServiceInfo]:
+    zeroconf = Zeroconf()
+    service_type = "_http._tcp.local."
+    service_name = f"{hostname}.{service_type}"
+    service_info = ServiceInfo(
+        type_=service_type,
+        name=service_name,
+        address=b"\x00\x00\x00\x00",  # Placeholder; this will be auto-detected
+        port=port,
+        properties={},
+        server=f"{hostname}.local.",
+    )
+    zeroconf.register_service(service_info)
+    return zeroconf, service_info

--- a/app/functions/multicast_dns.py
+++ b/app/functions/multicast_dns.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import socket
 
 from zeroconf import ServiceInfo, Zeroconf
 
@@ -13,10 +14,15 @@ class MulticastDNS:
         self.service_info = ServiceInfo(
             type_=self.service_type,
             name=f"{self.hostname}.{self.service_type}",
-            addresses=[b"\x00\x00\x00\x00"],  # Placeholder; this will be auto-detected
+            addresses=[self.get_hostname()],
             port=self.port,
             properties={},
             server=f"{self.hostname}.local.",
+        )
+
+    def get_hostname(self):
+        return socket.inet_aton(
+            socket.gethostbyname(socket.gethostname()),
         )
 
     async def register_service(self):

--- a/app/functions/multicast_dns.py
+++ b/app/functions/multicast_dns.py
@@ -1,17 +1,29 @@
+import asyncio
+import logging
+
 from zeroconf import ServiceInfo, Zeroconf
 
 
-def register_service(hostname: str, port: int) -> tuple[Zeroconf, ServiceInfo]:
-    zeroconf = Zeroconf()
-    service_type = "_http._tcp.local."
-    service_name = f"{hostname}.{service_type}"
-    service_info = ServiceInfo(
-        type_=service_type,
-        name=service_name,
-        address=b"\x00\x00\x00\x00",  # Placeholder; this will be auto-detected
-        port=port,
-        properties={},
-        server=f"{hostname}.local.",
-    )
-    zeroconf.register_service(service_info)
-    return zeroconf, service_info
+class MulticastDNS:
+    def __init__(self, hostname: str, port: int) -> None:
+        self.zeroconf = Zeroconf()
+        self.service_type = "_http._tcp.local."
+        self.hostname = hostname
+        self.port = port
+        self.service_info = ServiceInfo(
+            type_=self.service_type,
+            name=f"{self.hostname}.{self.service_type}",
+            addresses=[b"\x00\x00\x00\x00"],  # Placeholder; this will be auto-detected
+            port=self.port,
+            properties={},
+            server=f"{self.hostname}.local.",
+        )
+
+    async def register_service(self):
+        logging.info(f"Registering service {self.service_info.name}")
+        await asyncio.to_thread(self.zeroconf.register_service, self.service_info)
+
+    async def unregister_service(self):
+        logging.info(f"Unregistering service {self.service_info.name}")
+        await asyncio.to_thread(self.zeroconf.unregister_service, self.service_info)
+        await asyncio.to_thread(self.zeroconf.close)

--- a/app/functions/multicast_dns.py
+++ b/app/functions/multicast_dns.py
@@ -20,16 +20,16 @@ class MulticastDNS:
             server=f"{self.hostname}.local.",
         )
 
-    def get_hostname(self):
+    def get_hostname(self) -> bytes:
         return socket.inet_aton(
             socket.gethostbyname(socket.gethostname()),
         )
 
-    async def register_service(self):
+    async def register_service(self) -> None:
         logging.info(f"Registering service {self.service_info.name}")
         await asyncio.to_thread(self.zeroconf.register_service, self.service_info)
 
-    async def unregister_service(self):
+    async def unregister_service(self) -> None:
         logging.info(f"Unregistering service {self.service_info.name}")
         await asyncio.to_thread(self.zeroconf.unregister_service, self.service_info)
         await asyncio.to_thread(self.zeroconf.close)

--- a/app/models/common.py
+++ b/app/models/common.py
@@ -1,3 +1,5 @@
+import logging
+
 from sqlalchemy.orm import DeclarativeBase
 
 from app.database.db import engine
@@ -8,4 +10,6 @@ class Base(DeclarativeBase):
 
 
 def init_orm() -> None:
+    logging.info("Creating ORM tables from metadata...")
     Base.metadata.create_all(engine)
+    logging.info("Table creation done!")

--- a/poetry.lock
+++ b/poetry.lock
@@ -125,20 +125,6 @@ files = [
 ]
 
 [[package]]
-name = "click"
-version = "8.1.7"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
-    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -296,6 +282,32 @@ files = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.1.0"
+description = "HTTP/2 State-Machine based protocol implementation"
+optional = false
+python-versions = ">=3.6.1"
+files = [
+    {file = "h2-4.1.0-py3-none-any.whl", hash = "sha256:03a46bcf682256c95b5fd9e9a99c1323584c3eec6440d379b9903d709476bc6d"},
+    {file = "h2-4.1.0.tar.gz", hash = "sha256:a83aca08fbe7aacb79fec788c9c0bac936343560ed9ec18b82a13a12c28d2abb"},
+]
+
+[package.dependencies]
+hpack = ">=4.0,<5"
+hyperframe = ">=6.0,<7"
+
+[[package]]
+name = "hpack"
+version = "4.0.0"
+description = "Pure-Python HPACK header compression"
+optional = false
+python-versions = ">=3.6.1"
+files = [
+    {file = "hpack-4.0.0-py3-none-any.whl", hash = "sha256:84a076fad3dc9a9f8063ccb8041ef100867b1878b25ef0ee63847a5d53818a6c"},
+    {file = "hpack-4.0.0.tar.gz", hash = "sha256:fc41de0c63e687ebffde81187a948221294896f6bdc0ae2312708df339430095"},
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.6"
 description = "A minimal low-level HTTP client."
@@ -340,6 +352,40 @@ cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "hypercorn"
+version = "0.17.3"
+description = "A ASGI Server based on Hyper libraries and inspired by Gunicorn"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "hypercorn-0.17.3-py3-none-any.whl", hash = "sha256:059215dec34537f9d40a69258d323f56344805efb462959e727152b0aa504547"},
+    {file = "hypercorn-0.17.3.tar.gz", hash = "sha256:1b37802ee3ac52d2d85270700d565787ab16cf19e1462ccfa9f089ca17574165"},
+]
+
+[package.dependencies]
+h11 = "*"
+h2 = ">=3.1.0"
+priority = "*"
+wsproto = ">=0.14.0"
+
+[package.extras]
+docs = ["pydata_sphinx_theme", "sphinxcontrib_mermaid"]
+h3 = ["aioquic (>=0.9.0,<1.0)"]
+trio = ["trio (>=0.22.0)"]
+uvloop = ["uvloop (>=0.18)"]
+
+[[package]]
+name = "hyperframe"
+version = "6.0.1"
+description = "HTTP/2 framing layer for Python"
+optional = false
+python-versions = ">=3.6.1"
+files = [
+    {file = "hyperframe-6.0.1-py3-none-any.whl", hash = "sha256:0ec6bafd80d8ad2195c4f03aacba3a8265e57bc4cff261e802bf39970ed02a15"},
+    {file = "hyperframe-6.0.1.tar.gz", hash = "sha256:ae510046231dc8e9ecb1a6586f63d2347bf4c8905914aa84ba585ae85f28a914"},
+]
 
 [[package]]
 name = "idna"
@@ -491,6 +537,17 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "priority"
+version = "2.0.0"
+description = "A pure-Python implementation of the HTTP/2 priority tree"
+optional = false
+python-versions = ">=3.6.1"
+files = [
+    {file = "priority-2.0.0-py3-none-any.whl", hash = "sha256:6f8eefce5f3ad59baf2c080a664037bb4725cd0a790d53d59ab4059288faf6aa"},
+    {file = "priority-2.0.0.tar.gz", hash = "sha256:c965d54f1b8d0d0b19479db3924c7c36cf672dbf2aec92d43fbdaf4492ba18c0"},
+]
 
 [[package]]
 name = "psycopg2"
@@ -823,22 +880,18 @@ files = [
 ]
 
 [[package]]
-name = "uvicorn"
-version = "0.32.0"
-description = "The lightning-fast ASGI server."
+name = "wsproto"
+version = "1.2.0"
+description = "WebSockets state-machine based protocol implementation"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7.0"
 files = [
-    {file = "uvicorn-0.32.0-py3-none-any.whl", hash = "sha256:60b8f3a5ac027dcd31448f411ced12b5ef452c646f76f02f8cc3f25d8d26fd82"},
-    {file = "uvicorn-0.32.0.tar.gz", hash = "sha256:f78b36b143c16f54ccdb8190d0a26b5f1901fe5a3c777e1ab29f26391af8551e"},
+    {file = "wsproto-1.2.0-py3-none-any.whl", hash = "sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736"},
+    {file = "wsproto-1.2.0.tar.gz", hash = "sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065"},
 ]
 
 [package.dependencies]
-click = ">=7.0"
-h11 = ">=0.8"
-
-[package.extras]
-standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.4)"]
+h11 = ">=0.9.0,<1"
 
 [[package]]
 name = "zeroconf"
@@ -922,4 +975,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "7c167e6bfc8949bc37b0c1ca8c53fbd31e370806828dd56cd50ba2b5752b019d"
+content-hash = "60bb6d4538a6ef1a6edcb4d549e4e9ac320f88e2fc1fc07f82f022b944f39dbf"

--- a/poetry.lock
+++ b/poetry.lock
@@ -356,6 +356,17 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
+name = "ifaddr"
+version = "0.2.0"
+description = "Cross-platform network interface and IP address enumeration library"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748"},
+    {file = "ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4"},
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -829,7 +840,86 @@ h11 = ">=0.8"
 [package.extras]
 standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.4)"]
 
+[[package]]
+name = "zeroconf"
+version = "0.136.2"
+description = "A pure python implementation of multicast DNS service discovery"
+optional = false
+python-versions = "<4.0,>=3.8"
+files = [
+    {file = "zeroconf-0.136.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5dbd7a2d9fbce5623b05ecd7003fab95bc324dcb8e33b35ce796e8e915851e4d"},
+    {file = "zeroconf-0.136.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5b958e163ebbaeb1d2e01dcf62de8c44af566af97a93a7a969e515e522f4d83f"},
+    {file = "zeroconf-0.136.2-cp310-cp310-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:e6de231a0ba53a5b6fa6c2b9b6be8cc9e017404721fdb46316e4e28379ecc216"},
+    {file = "zeroconf-0.136.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c8a8d99828c14e45122f856d05bd66d19cd70ba5c9930aaee71f1ec6e28561c"},
+    {file = "zeroconf-0.136.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:90443a6006d2b721001f7db8f1e10e687e52229cff49075fcbcf66036c133c94"},
+    {file = "zeroconf-0.136.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b999043357fc4caedff042d6bea3cf7c7ca205c976e5c7233fe8d56a5cf346e0"},
+    {file = "zeroconf-0.136.2-cp310-cp310-win32.whl", hash = "sha256:117087d963883604792bc91118be0bcecde07c1c41189db8f835b1fd3bd27eaa"},
+    {file = "zeroconf-0.136.2-cp310-cp310-win_amd64.whl", hash = "sha256:d68d8cff8aa4b6e3b0722d853b9c70873add50503bc40f2b2bddb5856c6f6193"},
+    {file = "zeroconf-0.136.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c35e991091013cbe02907c4b798554c1081630925c8a94dcd652c2440fed8907"},
+    {file = "zeroconf-0.136.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1efe072eb34f51c2b5386981ab725a87d2ee31078ce4c5a488669eda10415cb6"},
+    {file = "zeroconf-0.136.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85ba59ab362e99dd9063a3321d6bf933b062847257e3248490051a042d61a130"},
+    {file = "zeroconf-0.136.2-cp311-cp311-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:7ce7ba8462f3baab4cd0332c929fde3dabc7d814a0381f33a3b871d9f7886626"},
+    {file = "zeroconf-0.136.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:019205377af6b2308476e6597b8ae34a7cfe6fe3b6e367b0ab405ff17c4d4d3b"},
+    {file = "zeroconf-0.136.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:d5437c28e0898ba018b52e23f6ffa9cefa2560649b50947e2220d6daa1b17db9"},
+    {file = "zeroconf-0.136.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c5a6007b0e3b938e5b6af4a12ee23ef997ca89068702aea5fc66baf216fbcbd"},
+    {file = "zeroconf-0.136.2-cp311-cp311-win32.whl", hash = "sha256:6afa19d0dcbfc656ecc987f33c313e30178a20d3731d17eb6c81388138954e8c"},
+    {file = "zeroconf-0.136.2-cp311-cp311-win_amd64.whl", hash = "sha256:0ac3f8b375d1e3954908de0d6245df6ca44d01ecbd2d50572a0d86fc18e7b1f2"},
+    {file = "zeroconf-0.136.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5a74474e4d5cda8ea121e7b9538660decce1b944a210a26134ca5852c1e12929"},
+    {file = "zeroconf-0.136.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1746e25128915417d1500e23cdb22f7460bb688978e4570cc956081fc85c408f"},
+    {file = "zeroconf-0.136.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb14c95c428ad003f0a8fdde87f0c0ba89a945ced468421ad24818e243e3fd0e"},
+    {file = "zeroconf-0.136.2-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:c44256cbc15e4dc8f5466e9f20a86325156b1a5d4bfc704167f93ed0653058b6"},
+    {file = "zeroconf-0.136.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9286e280d5aec66d0ac9ef662d953a08aba8b812c0e3273b790026b7c143ee98"},
+    {file = "zeroconf-0.136.2-cp312-cp312-manylinux_2_36_x86_64.whl", hash = "sha256:1e0f0df103bc27816b00b983cdc404423fd14daaa4708ad7764a9ca3830a333d"},
+    {file = "zeroconf-0.136.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:21351dca8727ba7c47d00f97de413b353ab2da72044fdae55eb32cf52998f5b6"},
+    {file = "zeroconf-0.136.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e908a3c93c15261416397c7acd624ad58b048e8027a048c07e35cb5fe1bab489"},
+    {file = "zeroconf-0.136.2-cp312-cp312-win32.whl", hash = "sha256:0ed19d4e0a2cfe57a19c6540253af6f254a5d79ed17af7dd14db125a9faa95de"},
+    {file = "zeroconf-0.136.2-cp312-cp312-win_amd64.whl", hash = "sha256:38b05678968dc2cfdef795f14efc16d5cb9163e008da5f15334bccc235f8c722"},
+    {file = "zeroconf-0.136.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ffc9bd9df2c30edfbc44c02413f1191d509ed7c749cd405172344320dc4bac03"},
+    {file = "zeroconf-0.136.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dbd29811c60382929fef9fe70dd85d3d0a26efd1a6068ced86b24ab7c15c9649"},
+    {file = "zeroconf-0.136.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88cc3744a4b8613765a49837c88fde2ff3f4b41fac0661591c7203391358f644"},
+    {file = "zeroconf-0.136.2-cp313-cp313-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:94b3df37ee57d0b77330aee6cb8a3612363ead8f04c57110751773945532e05e"},
+    {file = "zeroconf-0.136.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1d009191d7d13ba552d4c0dbb96792c5473c8d31668aa47343e324f0f61b0fbd"},
+    {file = "zeroconf-0.136.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756d8e5427026d12f42fe452952c19de3545ea16e70af0a999404c7ef196057b"},
+    {file = "zeroconf-0.136.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e63369e50f6aef945ee036e94d105ff6ec84498f6e7d6e456abac577916d4d2f"},
+    {file = "zeroconf-0.136.2-cp313-cp313-win32.whl", hash = "sha256:816f04d03625a876aa6d1b389c64f5421d5210a9bddf69c997ea1bb377970613"},
+    {file = "zeroconf-0.136.2-cp313-cp313-win_amd64.whl", hash = "sha256:ce480e2f84f2176c19f04d55bcd2ee540dc7262ad6eb8fc8194d1b98c9f33f2a"},
+    {file = "zeroconf-0.136.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:353685302d3f6068589672667e92298f2154e9546a266e8838201f9fa391464a"},
+    {file = "zeroconf-0.136.2-cp38-cp38-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:647c71fe7363b2f0afabb3a18d6aa7ef5090b96763994b036253b8306400a7bc"},
+    {file = "zeroconf-0.136.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cddb4a57016064cf5e2b31b31df39a35ad775a3974f4a70ac2aae2f2beb96f9a"},
+    {file = "zeroconf-0.136.2-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:1d0a545e7b62883c8a102b2386ab011dbb2fc1dbc2282cb4566254174d1097c6"},
+    {file = "zeroconf-0.136.2-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:224e15b94e6290fb0d48245fc7fc12d73539c121f767b28a13bb6b017854b18f"},
+    {file = "zeroconf-0.136.2-cp38-cp38-win32.whl", hash = "sha256:2d2e6ebd60f3874e8d2bc4a9e9ea3888fe47617398f18b8af6d42be662978b53"},
+    {file = "zeroconf-0.136.2-cp38-cp38-win_amd64.whl", hash = "sha256:4caa57e1cf1ca12841033d3bcf879de4f37ec744df742f6abe3bfa982f3a1a6f"},
+    {file = "zeroconf-0.136.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5934f63e5c1f300806ca575936c3461beae7e7c13859b158f5611228dd21bbb8"},
+    {file = "zeroconf-0.136.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:dda8fe421dcca543cef394395d8fc320a146e92f4b74597d3384a815df846be9"},
+    {file = "zeroconf-0.136.2-cp39-cp39-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:57a1aa69b3f9064aec1b33f03cdde82c6d07aaf88f6ce6d1674439c10f123b59"},
+    {file = "zeroconf-0.136.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:569a6f13c78710913744fe5ae7bfdaa1e9c7e64e7199881fb536e8ed6f6ce5b9"},
+    {file = "zeroconf-0.136.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:21b0018064bb3fb3429e1cdeb3239dd27da1a06ffba1bcb09a0df75ab984dc3f"},
+    {file = "zeroconf-0.136.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b592f77d0c82135f2cdf176f5c8269cc655f8f8abd11fa77c15d08a1a0f27029"},
+    {file = "zeroconf-0.136.2-cp39-cp39-win32.whl", hash = "sha256:eb00684f3723dbe8092b1830de37cce6af4cb00e06fdb3b1a0545887f46dc783"},
+    {file = "zeroconf-0.136.2-cp39-cp39-win_amd64.whl", hash = "sha256:d16c66d239a0578d70035fb506625278f99e3e5573f5939793bbffee3120cf29"},
+    {file = "zeroconf-0.136.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:97ee3439c9e10f51cb690923972d213fae5e2d2be63504f2f318255fa7471a6f"},
+    {file = "zeroconf-0.136.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:346688e5d28b370192d721fcf85a72193f8e7cf8f5e625bf1c111f00e404ca65"},
+    {file = "zeroconf-0.136.2-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:1a4d2946ad71b514279b6897911406a4b6f95b95efff6d4c9762f0818068ec9d"},
+    {file = "zeroconf-0.136.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4aaf4088a20800858797a9e03f38d698382ad2f54d2e9133b66dff5bc8a82c5"},
+    {file = "zeroconf-0.136.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3e79263b2482cfd39bfe2013c2517dfb76c52fe3f94a697d131cf1322738e61"},
+    {file = "zeroconf-0.136.2-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:f7232123bd499f0d99421062aacda38691c04f5fe578c70ad92cb520582d7295"},
+    {file = "zeroconf-0.136.2-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:d2339004240e54e9ca7510b53ab5d222c40a5b36e7e9c6a2026fac97b4951576"},
+    {file = "zeroconf-0.136.2-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:eb60a0c1f6e80050dd4ab335a3e59d2c6f2633f8215878098f93bb48c894d56c"},
+    {file = "zeroconf-0.136.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7307b65c248c96e86cac94ab10258e1180dd9ede4607eb384f2f034d7b18280"},
+    {file = "zeroconf-0.136.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:433a813b7a4b88d0e51522d3bd6dd725706d7782fabc47e02aa4a0e5bf2f58f9"},
+    {file = "zeroconf-0.136.2-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c8c545b4d1ac41610b9893367d039b009e6f73c0ba624fc19b89bb7e658140a"},
+    {file = "zeroconf-0.136.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:9daab7f2b37ad7af2b471ff08e25a09d93656595e0dc8dc7d0b5382fdd3ad568"},
+    {file = "zeroconf-0.136.2-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:b5cb94c63d4dcfb3ccc67e972e650573daf3e8d433e1c66a18c3cf6f9da6428d"},
+    {file = "zeroconf-0.136.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a3e52be2847aa0106ce66ceab93b3377a31b3baf74a627405d4c49c36e02b9c"},
+    {file = "zeroconf-0.136.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:d35db16391b1cfc76e6791b61ac1d13bbb98007c91cc3746723a90dd46944f11"},
+    {file = "zeroconf-0.136.2.tar.gz", hash = "sha256:37d223febad4569f0d14563eb8e80a9742be35d0419847b45d84c37fc4224bb4"},
+]
+
+[package.dependencies]
+ifaddr = ">=0.1.7"
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "ce26746829360520d34c9a3d087a0c71d165433b8d6f9881b841de392db7ebd9"
+content-hash = "7c167e6bfc8949bc37b0c1ca8c53fbd31e370806828dd56cd50ba2b5752b019d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pydantic-settings = "^2.6.1"
 uvicorn = "^0.32.0"
 asyncpg = "^0.30.0"
 psycopg2 = "^2.9.10"
+zeroconf = "^0.136.2"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,10 @@ pytest = "^8.3.3"
 fastapi = "^0.115.4"
 fastapi-mqtt = "^2.2.0"
 pydantic-settings = "^2.6.1"
-uvicorn = "^0.32.0"
 asyncpg = "^0.30.0"
 psycopg2 = "^2.9.10"
 zeroconf = "^0.136.2"
+hypercorn = "^0.17.3"
 
 
 [build-system]

--- a/run.py
+++ b/run.py
@@ -1,8 +1,14 @@
-import uvicorn
+import asyncio
 
-from app.config import UvicornConfig
+from hypercorn.asyncio import serve
+
+from app import app
+from app.config import ASGIConfig, HypercornConfig
+
+
+async def main():
+    await serve(app, HypercornConfig())
+
 
 if __name__ == "__main__":
-    uvicorn.run(
-        **UvicornConfig().model_dump(),
-    )
+    asyncio.run(main(), debug=True)

--- a/tests/manual/test_zeroconf.py
+++ b/tests/manual/test_zeroconf.py
@@ -1,0 +1,40 @@
+import time
+
+from zeroconf import ServiceBrowser, Zeroconf
+
+
+class MyListener:
+    def __init__(self):
+        self.services = {}
+
+    def add_service(self, zeroconf, type, name):
+        print(f"Service {name} of type {type} added.")
+        self.services[name] = type
+
+    def remove_service(self, zeroconf, type, name):
+        print(f"Service {name} of type {type} removed.")
+        if name in self.services:
+            del self.services[name]
+
+    def update_service(self, zeroconf, type, name):
+        print(f"Service {name} of type {type} updated.")
+
+
+def discover_services():
+    zeroconf = Zeroconf()
+    listener = MyListener()
+
+    # Service type '_http._tcp.local.' is an example; adjust as needed for your use case.
+    browser = ServiceBrowser(zeroconf, "_http._tcp.local.", listener)
+
+    try:
+        # Keep the service discovery running.
+        print("Discovering services...")
+        while True:
+            time.sleep(1)
+    finally:
+        zeroconf.close()
+
+
+if __name__ == "__main__":
+    discover_services()


### PR DESCRIPTION
MulticastDNS is used to easily resolves Hostnames to IP addresses within small networks that do not include a local name servers. It is a zero-configuration service, using essentially the same programming interfaces, packet formats and operating semantics as unicast DNS. 

Currently it can be disabled in class GeneralConfig `app/config.py`, but in later revision it should be possible to configure it using environment variables. 