### PR TITLE
IL-123 Feature MQTT connection info API route

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -4,6 +4,7 @@ from app.api.v1.asset_positions import asset_position_router
 from app.api.v1.assets import asset_router
 from app.api.v1.auth import auth_router
 from app.api.v1.floormaps import floormap_router
+from app.api.v1.mqtt import mqtt_router
 from app.api.v1.users import user_router
 from app.api.v1.zone_positions import zone_position_router
 from app.api.v1.zones import zone_router
@@ -14,6 +15,7 @@ v1_router.include_router(asset_position_router)
 v1_router.include_router(asset_router)
 v1_router.include_router(auth_router)
 v1_router.include_router(floormap_router)
+v1_router.include_router(mqtt_router)
 v1_router.include_router(user_router)
 v1_router.include_router(zone_position_router)
 v1_router.include_router(zone_router)

--- a/app/api/v1/mqtt.py
+++ b/app/api/v1/mqtt.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter
+
+from app.api.dependencies import get_current_user_with_scope
+from app.config import GeneralConfig
+from app.schemas.api.mqtt import MQTTCredentials
+from app.schemas.api.user import UserBase
+from app.schemas.auth.role_types import Role
+
+mqtt_router = APIRouter(prefix="/mqtt", tags=["MQTT"])
+
+
+@mqtt_router.get("/")
+def get_mqtt_credentials(
+    _: UserBase = get_current_user_with_scope([Role.USER]),
+) -> MQTTCredentials:
+    config = GeneralConfig()
+    return MQTTCredentials(
+        mqttUsername=config.mqtt_username,
+        mqttPassword=config.mqtt_password,
+        mqttServerAddress=config.mqtt_public_host,
+        mqttServerPort=config.mqtt_public_port,
+    )

--- a/app/config.py
+++ b/app/config.py
@@ -27,8 +27,10 @@ class GeneralConfig(BaseSettings):
     mdns_hostname: str = "mdns_dev"
     mdns_port: int = 8001
 
-    mqtt_host: str = "host_mqtt_example"
-    mqtt_port: int = 1883
+    mqtt_internal_host: str = "host_mqtt_example"
+    mqtt_internal_port: int = 1883
+    mqtt_public_host: str
+    mqtt_public_port: int = 1883
     mqtt_username: str
     mqtt_password: str
 

--- a/app/functions/mqtt_client.py
+++ b/app/functions/mqtt_client.py
@@ -37,8 +37,8 @@ class MQTTClientHandler:
         self.config = GeneralConfig()
         fast_mqtt = FastMQTT(
             config=MQTTConfig(
-                host=self.config.mqtt_host,
-                port=self.config.mqtt_port,
+                host=self.config.mqtt_internal_host,
+                port=self.config.mqtt_internal_port,
                 username=self.config.mqtt_username,
                 password=self.config.mqtt_password,
             )
@@ -55,8 +55,8 @@ class MQTTClientHandler:
             mqtt.client.subscribe("/test/topic")  # subscribing mqtt topic
             logging.info(
                 "Connected to MQTT broker %s:%d",
-                self.config.mqtt_host,
-                self.config.mqtt_port,
+                self.config.mqtt_internal_host,
+                self.config.mqtt_internal_port,
             )
 
         @mqtt.on_message()
@@ -69,8 +69,8 @@ class MQTTClientHandler:
         def disconnect(_client: MQTTClient, _packet: Any, _exc: Any | None = None):
             logging.info(
                 "[MQTT] Disconnected from MQTT broker %s:%d",
-                self.config.mqtt_host,
-                self.config.mqtt_port,
+                self.config.mqtt_internal_host,
+                self.config.mqtt_internal_port,
             )
 
         @mqtt.on_subscribe()

--- a/app/schemas/api/mqtt.py
+++ b/app/schemas/api/mqtt.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class MQTTCredentials(BaseModel):
+    mqttServerAddress: str
+    mqttServerPort: int
+    mqttUsername: str
+    mqttPassword: str


### PR DESCRIPTION
This PR aims to add the ability to share MQTT connection info on `/mqtt` path. When we configure a reverse proxy for the broker's WS/WSS port the backend will return that proxies address and port.